### PR TITLE
Make sure app is not defined twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
 module.exports = {
   name: 'ember-cli-bootstrap-datepicker',
 
-  included: function(app) {
+  included() {
     let findHost = this._findHost || findHostShim;
     let app = findHost.call(this);
 


### PR DESCRIPTION
Current code throws the following error,
```js
Identifier 'app' has already been declared
/home/vagrant/s2bv4-ui-core/addons/reporting-engine/node_modules/ember-cli-datepicker-bootstrap/index.js:21
    let app = findHost.call(this);
```

I removed app argument to prevent double defined app.